### PR TITLE
Fix `days_shift` run task

### DIFF
--- a/sddc_osw_multifamily/ze_multifamily/measures/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/sddc_osw_multifamily/ze_multifamily/measures/HPXMLtoOpenStudio/resources/schedules.rb
@@ -612,7 +612,7 @@ class HotWaterSchedule
 
     # Read data into minute array
     skippedheader = false
-    min_shift = 24 * 60 * (days_shift % 365) # For MF homes, shift each unit by an additional week
+    min_shift = 24 * 60 * (days_shift) # For MF homes, shift each unit by an additional week
     items = [0] * minutes_in_year
     File.open(minute_draw_profile).each do |line|
       linedata = line.strip.split(',')


### PR DESCRIPTION
Add an incrementer operator +=7 to the building_unit array each loop so that the each unit shifts its schedule by 7 days. Schedule is still a repeating single week for the whole year.