### PR TITLE
Update schedules.rb to change `weeks` to 2

### DIFF
--- a/sddc_osw_multifamily/ze_multifamily/measures/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/sddc_osw_multifamily/ze_multifamily/measures/HPXMLtoOpenStudio/resources/schedules.rb
@@ -543,7 +543,7 @@ class HotWaterSchedule
     end
 
     timestep_minutes = (60 / @model.getTimestep.numberOfTimestepsPerHour).to_i
-    weeks = 1 # use a single week that repeats
+    weeks = 2 # use two weeks that repeat
 
     data = loadMinuteDrawProfileFromFile(timestep_minutes, days_shift, weeks)
     @totflow, @maxflow, @ontime = loadDrawProfileStatsFromFile()


### PR DESCRIPTION
The fractional schedule is now on a two week basis. Schedule repeats every 2 weeks. Still shifted by unit_index.